### PR TITLE
Fix misspellings on sample/index.html

### DIFF
--- a/sample/index.html
+++ b/sample/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="fontello.css">
   <link rel="stylesheet" type="text/css" href="../dist/latest.css">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta name="description" content="Unpack your meal and start coding. A lighweight CSS library with nice defaults to give you a fast start.">
+  <meta name="description" content="Unpack your meal and start coding. A lightweight CSS library with nice defaults to give you a fast start.">
   <meta name="keywords" content="css, library, css library, picnic, picnicss, html, html5">
   <link rel="icon" type="image/png" href="http://picnicss.com/basket.png">
 


### PR DESCRIPTION
I noticed the description meta tag was saying "Unpack your mean..." when I pasted the link in Slack. Cheers!
