### PR TITLE
Updated CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ There are many ways of using Picnic CSS in your projects. Here a brief introduct
 
 ### CDN - just give me the file
 
-Use [Picnic CSS in the CDN jsDelivr](http://www.jsdelivr.com/#!picnicss) for linking to the static file.
+Use [Picnic CSS in the CDN jsDelivr](https://cdn.jsdelivr.net/npm/picnic/) for linking to the static file.
+
+Load latest 6.x version https://cdn.jsdelivr.net/npm/picnic@6
 
 
 ### Bower - to personalize Picnic


### PR DESCRIPTION
jsDelivr is using a new /npm/ endpoint to automatically support all npm projects. So I updated the links to make sure they show the latest versions. (the site will be updated soon)

More info https://github.com/jsdelivr/jsdelivr#usage