### PR TITLE
Correct mismatched closing tags

### DIFF
--- a/tests.html
+++ b/tests.html
@@ -84,7 +84,7 @@
         <input type="checkbox" id="cardtoggle">
         <article class="card">
           <p>Paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore...</p>
-          <label for="cardtoggle" class="close">×</a>
+          <label for="cardtoggle" class="close">×</label>
         </article>
       </div>
     </div>
@@ -93,7 +93,7 @@
       <article class="card">
         <header>
           <h1>Header 1</h1>
-          <label for="cardtoggle2" class="close">×</a>
+          <label for="cardtoggle2" class="close">×</label>
         </header>
       </article>
       <input id="cardtoggle3" type="checkbox" name="name2">


### PR DESCRIPTION
This two-line fix corrects a typo in the `tests.html` file where two `<label>` elements were being closed with an `</a>` instead of `</label>`.