### PR TITLE
Fix styling for select[multiple]

### DIFF
--- a/src/plugins/select/_class.scss
+++ b/src/plugins/select/_class.scss
@@ -58,4 +58,10 @@ $picnic-select-dropimage: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d
     font-size: inherit;
     padding: $picnic-separation / 2 $picnic-separation * .75;
     }
+  
+  [multiple] {
+    height: auto;
+    background: none;
+    padding: 0;
+    }
   }


### PR DESCRIPTION
For multi-select dropdowns, we need to remove the arrow.svg and let it grow vertically to fit the list of items. Also, removing padding brings the option element text in alignment with regular select elements and inputs.