### PR TITLE
Removed slash division and replaced with math.div

### DIFF
--- a/src/picnic.scss
+++ b/src/picnic.scss
@@ -1,7 +1,10 @@
 //! Picnic CSS http://www.picnicss.com/
 
+// Loads the Sass Math Module 
+@use 'sass:math';
+
 // Imports the base variable styles
-@import './themes/default/theme';
+@import './themes/squared/theme';
 
 @import './vendor/compass-breakpoint/stylesheets/breakpoint';
 

--- a/src/plugins/button/_class.scss
+++ b/src/plugins/button/_class.scss
@@ -4,11 +4,11 @@
 
 
 // Variables
-$picnic-button-margin: $picnic-separation / 2 0 !default;
+$picnic-button-margin: math.div($picnic-separation, 2) 0 !default;
 $picnic-button-padding: $picnic-label-padding !default;
 $picnic-button-hover: inset 0 0 0 99em rgba($picnic-white, $picnic-transparency) !default;
 $picnic-button-click: inset 0 0 0 99em rgba($picnic-black, $picnic-transparency) !default;
-$picnic-button-pseudo-hover: inset 0 0 0 99em rgba($picnic-black, $picnic-transparency / 2) !default;
+$picnic-button-pseudo-hover: inset 0 0 0 99em rgba($picnic-black, math.div($picnic-transparency, 2)) !default;
 $picnic-button-transition: $picnic-transition !default;
 $picnic-button-radius: $picnic-label-radius !default;
 

--- a/src/plugins/card/_class.scss
+++ b/src/plugins/card/_class.scss
@@ -87,7 +87,7 @@ $picnic-card-radius: $picnic-radius !default;
     }
 
   p {
-    margin: $picnic-separation / 2 0;
+    margin: math.div($picnic-separation, 2) 0;
 
     &:first-child {
       margin-top: 0;

--- a/src/plugins/dropimage/_class.scss
+++ b/src/plugins/dropimage/_class.scss
@@ -5,10 +5,10 @@
 // Variables
 
 // The ratio for the images (responsive by default)
-$picnic-dropimage-ratio: 16 / 9 !default;
+$picnic-dropimage-ratio: math.div(16, 9) !default;
 
 // The percentage of height (respect of width)
-$picnic-dropimage-height: percentage(1 / $picnic-dropimage-ratio) !default;
+$picnic-dropimage-height: percentage(math.div(1, $picnic-dropimage-ratio)) !default;
 
 $picnic-dropimage-background-color: #ddd !default;
 

--- a/src/plugins/generic/_plugin.scss
+++ b/src/plugins/generic/_plugin.scss
@@ -31,7 +31,7 @@ h6 {
 }
 
 li {
-  margin: 0 0 $picnic-separation / 2;
+  margin: 0 0 math.div($picnic-separation, 2);
 }
 
 a {
@@ -45,14 +45,14 @@ a {
 // The <pre> doesn't have a nice style from Normalize.css
 
 code {
-  padding: $picnic-separation / 2 $picnic-separation;
+  padding: math.div($picnic-separation, 2) $picnic-separation;
   font-size: .8em;
   background: #f5f5f5;
 }
 
 pre {
   text-align: left;
-  padding: $picnic-separation / 2 $picnic-separation;
+  padding: math.div($picnic-separation, 2);
   background: #f5f5f5;
   border-radius: $picnic-radius;
 

--- a/src/plugins/input/_class.scss
+++ b/src/plugins/input/_class.scss
@@ -1,7 +1,7 @@
 
 // Variables
 $picnic-input-height: 2.1em !default;
-$picnic-input-padding: $picnic-separation / 2 $picnic-separation !default;
+$picnic-input-padding: math.div($picnic-separation, 2) $picnic-separation !default;
 $picnic-input-background: $picnic-white !default;
 
 

--- a/src/plugins/label/_class.scss
+++ b/src/plugins/label/_class.scss
@@ -1,5 +1,5 @@
 // Label of text
-$picnic-label-padding: $picnic-separation / 2 $picnic-separation * 1.5 !default;
+$picnic-label-padding: math.div($picnic-separation, 2) * 1.5 !default;
 $picnic-label-radius: $picnic-radius !default;
 
 // Styles

--- a/src/plugins/nav/_plugin.scss
+++ b/src/plugins/nav/_plugin.scss
@@ -62,7 +62,7 @@ nav {
         max-width: 300px;
         // max-width: 0;
         transform-origin: center right;
-        transition: all $picnic-nav-timing / 2 ease;
+        transition: all math.div($picnic-nav-timing, 2) ease;
 
         // opacity: 0;
         // width: 0;
@@ -108,13 +108,13 @@ nav {
 
       .burger ~ .menu > * {
         display: block;
-        margin: $picnic-separation / 2;
+        margin: math.div($picnic-separation, 2);
         text-align: left;
         max-width: calc(100% - #{$picnic-separation});
       }
 
       .burger ~ .menu > a {
-        padding: $picnic-separation / 2 $picnic-separation * 1.5;
+        padding: math.div($picnic-separation, 2) $picnic-separation * 1.5;
       }
     }
   }

--- a/src/plugins/select/_class.scss
+++ b/src/plugins/select/_class.scss
@@ -1,7 +1,7 @@
 // Variables
 $picnic-select-height: 2.2em !default;
-$picnic-select-margin: $picnic-separation / 2 !default;
-$picnic-select-padding: $picnic-separation / 2 $picnic-separation * 0.75 !default;
+$picnic-select-margin: math.div($picnic-separation, 2) !default;
+$picnic-select-padding: math.div($picnic-separation, 2) $picnic-separation * 0.75 !default;
 
 // This comes from arrow.svg. Converted with:
 // http://dopiaza.org/tools/datauri/index.php

--- a/src/plugins/table/_plugin.scss
+++ b/src/plugins/table/_plugin.scss
@@ -4,7 +4,7 @@ table {
 
 td,
 th {
-  padding: $picnic-separation / 2 2.4em $picnic-separation / 2 $picnic-separation;
+  padding: math.div($picnic-separation, 2) 2.4em math.div($picnic-separation, 2) $picnic-separation;
   }
 
 th {


### PR DESCRIPTION
Hi,

Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0. More information can be found at [here](https://sass-lang.com/d/slash-div).

I have replaced all slash division with math.div() and imported loaded the math module.

Thank you! 